### PR TITLE
Add support for WordPress 6.1

### DIFF
--- a/movabletype-importer.php
+++ b/movabletype-importer.php
@@ -337,6 +337,32 @@ if ( version_compare(get_bloginfo('version'), '3.8.0', '<') ) {
 		//ob_flush();flush();
 	}
 
+	private function create_post() {
+		$post = new StdClass();
+
+		$post->post_content = '';
+		$post->extended = '';
+		$post->post_excerpt = '';
+		$post->post_keywords = '';
+		$post->categories = array();
+
+		return $post;
+	}
+
+	private function create_comment() {
+		$comment = new StdClass();
+
+		$comment->comment_content = '';
+		$comment->comment_author = '';
+		$comment->comment_author_url = '';
+		$comment->comment_author_email = '';
+		$comment->comment_author_IP = '';
+		$comment->comment_date = null;
+		$comment->comment_post_ID = null;
+
+		return $comment;
+	}
+
 	function process_posts() {
 		global $wpdb;
 
@@ -345,10 +371,10 @@ if ( version_compare(get_bloginfo('version'), '3.8.0', '<') ) {
 			return false;
 
 		$context = '';
-		$post = new StdClass();
-		$comment = new StdClass();
+		$post = $this->create_post();
+		$comment = $this->create_comment();
 		$comments = array();
-		$ping = new StdClass();
+		$ping = $this->create_comment();
 		$pings = array();
 
 		echo "<div class='wrap'><ol>";
@@ -378,22 +404,24 @@ if ( version_compare(get_bloginfo('version'), '3.8.0', '<') ) {
 				// Finishing a multi-line field
 				if ( 'comment' == $context ) {
 					$comments[] = $comment;
-					$comment = new StdClass();
+					$comment = $this->create_comment();
 				} else if ( 'ping' == $context ) {
 					$pings[] = $ping;
-					$ping = new StdClass();
+					$ping = $this->create_comment();
 				}
 				$context = '';
 			} else if ( '--------' == $line ) {
 				// Finishing a post.
 				$context = '';
 				$result = $this->save_post($post, $comments, $pings);
-				if ( is_wp_error( $result ) )
+				if ( is_wp_error( $result ) ) {
 					return $result;
-				$post = new StdClass;
-				$comment = new StdClass();
-				$ping = new StdClass();
+				}
+
+				$post = $this->create_post();
+				$comment = $this->create_comment();
 				$comments = array();
+				$ping = $this->create_comment();
 				$pings = array();
 			} else if ( 'BODY:' == $line ) {
 				$context = 'body';

--- a/movabletype-importer.php
+++ b/movabletype-importer.php
@@ -413,7 +413,7 @@ if ( version_compare( get_bloginfo( 'version' ), '3.8.0', '<' ) ) {
 			} else if ( '--------' == $line ) {
 				// Finishing a post.
 				$context = '';
-				$result = $this->save_post($post, $comments, $pings);
+				$result = $this->save_post( $post, $comments, $pings );
 				if ( is_wp_error( $result ) ) {
 					return $result;
 				}

--- a/movabletype-importer.php
+++ b/movabletype-importer.php
@@ -50,7 +50,7 @@ class MT_Import extends WP_Importer {
 	function header() {
 		echo '<div class="wrap">';
 
-		if ( version_compare(get_bloginfo('version'), '3.8.0', '<') ) {
+		if ( version_compare( get_bloginfo( 'version' ), '3.8.0', '<' ) ) {
 			screen_icon();
 		}
 
@@ -85,7 +85,7 @@ class MT_Import extends WP_Importer {
 	}
 
 	function users_form($n) {
-		$users = version_compare(get_bloginfo('version'), '3.1.0', '<') ? get_users_of_blog() : get_users();
+		$users = version_compare( get_bloginfo( 'version' ), '3.1.0', '<' ) ? get_users_of_blog() : get_users();
 ?><select name="userselect[<?php echo $n; ?>]">
 	<option value="#NONE#"><?php _e('&mdash; Select &mdash;', 'movabletype-importer') ?></option>
 	<?php
@@ -217,7 +217,7 @@ class MT_Import extends WP_Importer {
 ?>
 <div class="wrap">
 <?php
-if ( version_compare(get_bloginfo('version'), '3.8.0', '<') ) {
+if ( version_compare( get_bloginfo( 'version' ), '3.8.0', '<' ) ) {
 	screen_icon();
 }
 ?>

--- a/movabletype-importer.php
+++ b/movabletype-importer.php
@@ -49,7 +49,11 @@ class MT_Import extends WP_Importer {
 
 	function header() {
 		echo '<div class="wrap">';
-		screen_icon();
+
+		if ( version_compare(get_bloginfo('version'), '3.8.0', '<') ) {
+			screen_icon();
+		}
+
 		echo '<h2>'.__('Import Movable Type or TypePad', 'movabletype-importer').'</h2>';
 	}
 
@@ -81,7 +85,7 @@ class MT_Import extends WP_Importer {
 	}
 
 	function users_form($n) {
-		$users = get_users_of_blog();
+		$users = version_compare(get_bloginfo('version'), '3.1.0', '<') ? get_users_of_blog() : get_users();
 ?><select name="userselect[<?php echo $n; ?>]">
 	<option value="#NONE#"><?php _e('&mdash; Select &mdash;', 'movabletype-importer') ?></option>
 	<?php
@@ -212,7 +216,11 @@ class MT_Import extends WP_Importer {
 	function mt_authors_form() {
 ?>
 <div class="wrap">
-<?php screen_icon(); ?>
+<?php
+if ( version_compare(get_bloginfo('version'), '3.8.0', '<') ) {
+	screen_icon();
+}
+?>
 <h2><?php _e('Assign Authors', 'movabletype-importer'); ?></h2>
 <p><?php _e('To make it easier for you to edit and save the imported posts and drafts, you may want to change the name of the author of the posts. For example, you may want to import all the entries as admin&#8217;s entries.', 'movabletype-importer'); ?></p>
 <p><?php _e('Below, you can see the names of the authors of the Movable Type posts in <em>italics</em>. For each of these names, you can either pick an author in your WordPress installation from the menu, or enter a name for the author in the textbox.', 'movabletype-importer'); ?></p>
@@ -344,7 +352,7 @@ class MT_Import extends WP_Importer {
 		$pings = array();
 
 		echo "<div class='wrap'><ol>";
-		
+
 		// disable some slowdown points, turn them back on later
 		wp_suspend_cache_invalidation( true );
 		wp_defer_term_counting( true );
@@ -354,16 +362,16 @@ class MT_Import extends WP_Importer {
 		if ( !WP_MT_IMPORT_FORCE_AUTOCOMMIT ) {
 			$wpdb->query('SET autocommit = 0');
 		}
-		
+
 		$count = 0;
 		while ( $line = $this->fgets($handle) ) {
-			
+
 			// commit once every 500 posts
 			$count++;
 			if ( !WP_MT_IMPORT_FORCE_AUTOCOMMIT && $count % 500 === 0 ) {
 				$wpdb->query('COMMIT');
 			}
-			
+
 			$line = trim($line);
 
 			if ( '-----' == $line ) {
@@ -501,13 +509,13 @@ class MT_Import extends WP_Importer {
 		$this->fclose($handle);
 
 		echo '</ol>';
-		
+
 		// commit the changes, turn autocommit back on
 		if ( !WP_MT_IMPORT_FORCE_AUTOCOMMIT ) {
 			$wpdb->query('COMMIT');
 			$wpdb->query('SET autocommit = 1');
 		}
-		
+
 		// turn basic caching and counting back on, flush the cache. This will also cause a full count to be performed for terms and comments
 		wp_suspend_cache_invalidation( false );
 		wp_cache_flush();

--- a/movabletype-importer.php
+++ b/movabletype-importer.php
@@ -5,7 +5,7 @@ Plugin URI: http://wordpress.org/extend/plugins/movabletype-importer/
 Description: Import posts and comments from a Movable Type or TypePad blog.
 Author: wordpressdotorg
 Author URI: http://wordpress.org/
-Version: 0.5-beta
+Version: 0.6
 License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Plugin Name ===
 Contributors: wordpressdotorg
-Donate link: 
+Donate link:
 Tags: importer, movable type, typepad
 Requires at least: 3.0
-Tested up to: 4.1
-Stable tag: 0.4
+Tested up to: 6.1
+Stable tag: 0.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -25,6 +25,9 @@ Import posts and comments from a Movable Type or TypePad blog.
 == Screenshots ==
 
 == Changelog ==
+
+= 0.6 =
+* Add support for WordPress 6.1
 
 = 0.5 =
 * Remove comment_exists check for importing comments. In testing, I found no duplicated comments via this method, and it's extremely slow on large imports. If this check is needed, then define('WP_MT_IMPORT_ALLOW_DUPE_COMMENTS', false);


### PR DESCRIPTION
This PR fixes the plugins and adds support for WordPress 6.1 and upgrades to plugin to 0.6.

1. Tested with WordPress `6.1`
2. Tested with PHP `7.4.33`
3. The `screen_icon` function is now deprecated. Added a check for WordPress 3.8.0
4. The `get_users_of_blog` function is now deprecated. Added a check for WordPress 3.1.0
5. Removed all the `stdClass::member_name not defined` warnings

How to test:
1. Clone the plugin
2. Spin a new docker image[^1]
3. Substitute `YOUR_FOLDER` with the path of the cloned plugin
4. Go to `http://localhost/wp-admin/plugins.php` and activate **Movable Type and TypePad**
5. Open `http://localhost/wp-admin/admin.php?import=mt`
6. Open a sample `mt-export.txt` file or `mt-export.txt.gz`. Found [one in the wild](https://allfortheboys.com/storage/mt-export.txt). The file is big and must be gzipped first
7. Load the file and import
8. The plugin must load correctly and no errors displayed
9. Check if the various posts/comments have been created

[^1]: `docker-compose.yml` file
```yaml
services:
  db:
    image: mariadb:latest
    command: '--default-authentication-plugin=mysql_native_password'
    volumes:
      - db_data:/var/lib/mysql
    restart: always
    environment:
      - MYSQL_ROOT_PASSWORD=somewordpress
      - MYSQL_DATABASE=wordpress
      - MYSQL_USER=wordpress
      - MYSQL_PASSWORD=wordpress
    expose:
      - 3306
      - 33060
  wordpress:
    image: wordpress:latest
    volumes:
      - wp_data:/var/www/html
      - YOUR_FOLDER:/var/www/html/wp-content/plugins/movabletype-importer
    ports:
      - 80:80
    restart: always
    environment:
      - WORDPRESS_DB_HOST=db
      - WORDPRESS_DB_USER=wordpress
      - WORDPRESS_DB_PASSWORD=wordpress
      - WORDPRESS_DB_NAME=wordpress
      - WORDPRESS_DEBUG=1
volumes:
  db_data:
  wp_data:
```
