### PR TITLE
Add support for WordPress 6.2

### DIFF
--- a/.github/workflows/asset-readme.yml
+++ b/.github/workflows/asset-readme.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: WordPress.org plugin asset/readme update
       uses: 10up/action-wordpress-plugin-asset-update@stable

--- a/movabletype-importer.php
+++ b/movabletype-importer.php
@@ -5,7 +5,7 @@ Plugin URI: http://wordpress.org/extend/plugins/movabletype-importer/
 Description: Import posts and comments from a Movable Type or TypePad blog.
 Author: wordpressdotorg
 Author URI: http://wordpress.org/
-Version: 0.6
+Version: 0.7
 License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: wordpressdotorg
 Donate link:
 Tags: importer, movable type, typepad
 Requires at least: 3.0
-Tested up to: 6.1
-Stable tag: 0.6
+Tested up to: 6.2
+Stable tag: 0.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -25,6 +25,9 @@ Import posts and comments from a Movable Type or TypePad blog.
 == Screenshots ==
 
 == Changelog ==
+
+= 0.7 =
+* Add support for WordPress 6.2
 
 = 0.6 =
 * Add support for WordPress 6.1


### PR DESCRIPTION
This PR adds support for WordPress 6.2 and upgrades the plugin to 0.7.

- Tested with WordPress 6.2
- Tested with PHP 5.6, PHP 7.4, PHP 8.0

How to test:

- Clone the plugin under your working directory
- Using `wp-env` to test, if you haven't installed it, please visit [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/#quick-tldr-instructions) for instructions
- It'll be easier if you have a `.wp-env.json` file at the root folder. For example, if your root folder is `oss-importer` and you can clone the plugin under this folder. Create `.wp.-env.json` file, you can change PHP version to the one you want to test with.
```
{
  "phpVersion": "5.6",
  "plugins": ["./movabletype-importer"]
}
``` 
- Run `wp-env start` to spin up the WordPress
- Navigate to `http://localhost:8888/wp-admin/admin.php?import=mt` and perform an import
- Import the content; it can take a while if you have a lot of content. If the script timeout, you need to set_time_limit to a higher value
- Check and see if the import works fine without errors