### PR TITLE
Fix versioning issue by using 0.6.1

### DIFF
--- a/movabletype-importer.php
+++ b/movabletype-importer.php
@@ -5,7 +5,7 @@ Plugin URI: http://wordpress.org/extend/plugins/movabletype-importer/
 Description: Import posts and comments from a Movable Type or TypePad blog.
 Author: wordpressdotorg
 Author URI: http://wordpress.org/
-Version: 0.7
+Version: 0.6.1
 License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link:
 Tags: importer, movable type, typepad
 Requires at least: 3.0
 Tested up to: 6.2
-Stable tag: 0.7
+Stable tag: 0.6.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -26,8 +26,8 @@ Import posts and comments from a Movable Type or TypePad blog.
 
 == Changelog ==
 
-= 0.7 =
-* Add support for WordPress 6.2
+= 0.6.1 =
+* Test the plugin up to WordPress 6.2
 
 = 0.6 =
 * Add support for WordPress 6.1


### PR DESCRIPTION
Based on the suggestion [here](https://github.com/WordPress/movabletype-importer/pull/3#issuecomment-1500254233)  we should use patch version here