### PR TITLE
Test plugin for WordPress 6.3

### DIFF
--- a/movabletype-importer.php
+++ b/movabletype-importer.php
@@ -5,7 +5,7 @@ Plugin URI: https://wordpress.org/extend/plugins/movabletype-importer/
 Description: Import posts and comments from a Movable Type or TypePad blog.
 Author: wordpressdotorg
 Author URI: https://wordpress.org/
-Version: 0.6.1
+Version: 0.6.2
 License: GPL version 2 or later - https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 

--- a/movabletype-importer.php
+++ b/movabletype-importer.php
@@ -5,7 +5,7 @@ Plugin URI: https://wordpress.org/extend/plugins/movabletype-importer/
 Description: Import posts and comments from a Movable Type or TypePad blog.
 Author: wordpressdotorg
 Author URI: https://wordpress.org/
-Version: 0.6.2
+Version: 0.6.1
 License: GPL version 2 or later - https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: wordpressdotorg
 Donate link:
 Tags: importer, movable type, typepad
 Requires at least: 3.0
-Tested up to: 6.2
-Stable tag: 0.6.1
+Tested up to: 6.3
+Stable tag: 0.6.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -25,6 +25,9 @@ Import posts and comments from a Movable Type or TypePad blog.
 == Screenshots ==
 
 == Changelog ==
+
+= 0.6.2 =
+* Test the plugin up to WordPress 6.3
 
 = 0.6.1 =
 * Test the plugin up to WordPress 6.2

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link:
 Tags: importer, movable type, typepad
 Requires at least: 3.0
 Tested up to: 6.3
-Stable tag: 0.6.2
+Stable tag: 0.6.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -25,9 +25,6 @@ Import posts and comments from a Movable Type or TypePad blog.
 == Screenshots ==
 
 == Changelog ==
-
-= 0.6.2 =
-* Test the plugin up to WordPress 6.3
 
 = 0.6.1 =
 * Test the plugin up to WordPress 6.2


### PR DESCRIPTION
In this PR, we test the plugin for WordPress 6.3.

## How to test

1. Clone this PR
2. Using `wp-env` run an instance. The minimum PHP version is 7.0 because WordPress 6.3 [dropped support for PHP 5](https://make.wordpress.org/core/2023/07/05/dropping-support-for-php-5/).
3. Go to `http://localhost:8888/wp-admin/admin.php?import=mt` and perform an import.
4. Check if the content has been imported and no errors are being generated.