### PR TITLE
Update tested up to label and stable tag

### DIFF
--- a/movabletype-importer.php
+++ b/movabletype-importer.php
@@ -5,7 +5,7 @@ Plugin URI: https://wordpress.org/extend/plugins/movabletype-importer/
 Description: Import posts and comments from a Movable Type or TypePad blog.
 Author: wordpressdotorg
 Author URI: https://wordpress.org/
-Version: 0.6.1
+Version: 0.6.2
 License: GPL version 2 or later - https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: wordpressdotorg
 Donate link:
 Tags: importer, movable type, typepad
 Requires at least: 3.0
-Tested up to: 6.3
-Stable tag: 0.6.1
+Tested up to: 6.4.2
+Stable tag: 0.6.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -25,6 +25,10 @@ Import posts and comments from a Movable Type or TypePad blog.
 == Screenshots ==
 
 == Changelog ==
+
+= 0.6.2 =
+* Testing the plugin up to WordPress 6.4.2
+* Update link references from http to https.
 
 = 0.6.1 =
 * Test the plugin up to WordPress 6.2


### PR DESCRIPTION
- This PR test for WordPress 6.4.2 with PHP 7.0, 7.4 and 8.0.
- Since there was changes gets merged and not bumping the version previously, we also need to taking care of it and bumping the version to `0.3.2` here.
- Related changes: https://github.com/WordPress/movabletype-importer/pull/5

### How to test

- Clone the plugin under your working directory
- Using `wp-env` to test, if you haven't installed it, please visit [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/#quick-tldr-instructions) for instructions
- It'll be easier if you have a `.wp-env.json` file at the root folder. For example, if your root folder is `oss-importer` and you can clone the plugin under this folder. Create `.wp.-env.json` file, you can change PHP version to the one you want to test with.
```
{
  "phpVersion": "7.0",
  "plugins": ["./movabletype-importer"]
}
``` 
- Run `wp-env start` to spin up the WordPress
- Navigate to `http://localhost:8888/wp-admin/admin.php?import=mt` and perform an import
- Import the content; it can take a while if you have a lot of content. If the script timeout, you need to set_time_limit to a higher value
- Check and see if the import works fine without errors