### PR TITLE
Test plugin for WordPress 6.6.2 and add fix issue with mt-export.txt

### DIFF
--- a/movabletype-importer.php
+++ b/movabletype-importer.php
@@ -5,7 +5,7 @@ Plugin URI: https://wordpress.org/extend/plugins/movabletype-importer/
 Description: Import posts and comments from a Movable Type or TypePad blog.
 Author: wordpressdotorg
 Author URI: https://wordpress.org/
-Version: 0.6.2
+Version: 0.6.3
 License: GPL version 2 or later - https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 */
 

--- a/movabletype-importer.php
+++ b/movabletype-importer.php
@@ -262,7 +262,7 @@ if ( version_compare( get_bloginfo( 'version' ), '3.8.0', '<' ) ) {
 			return;
 		}
 		$this->file = $file['file'];
-		$this->id = (int) $file['id'];
+		$this->id = array_key_exists( 'id', $file ) ? (int) $file['id'] : 0;
 
 		$this->mt_authors_form();
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wordpressdotorg
 Donate link:
 Tags: importer, movable type, typepad
 Requires at least: 3.0
-Tested up to: 6.6.2
+Tested up to: 6.6
 Stable tag: 0.6.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: wordpressdotorg
 Donate link:
 Tags: importer, movable type, typepad
 Requires at least: 3.0
-Tested up to: 6.4.2
-Stable tag: 0.6.2
+Tested up to: 6.6.2
+Stable tag: 0.6.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -25,6 +25,10 @@ Import posts and comments from a Movable Type or TypePad blog.
 == Screenshots ==
 
 == Changelog ==
+
+= 0.6.3 =
+* Testing the plugin up to WordPress 6.4.2
+* Fix warning when `mt-export.txt` is used
 
 = 0.6.2 =
 * Testing the plugin up to WordPress 6.4.2

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wordpressdotorg
 Donate link:
 Tags: importer, movable type, typepad
 Requires at least: 3.0
-Tested up to: 6.6
+Tested up to: 6.7
 Stable tag: 0.6.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -27,7 +27,7 @@ Import posts and comments from a Movable Type or TypePad blog.
 == Changelog ==
 
 = 0.6.3 =
-* Testing the plugin up to WordPress 6.4.2
+* Testing the plugin up to WordPress 6.7
 * Fix warning when `mt-export.txt` is used
 
 = 0.6.2 =


### PR DESCRIPTION
This PR updates the `Tested up to` label to WordPress 6.6.2 and removes PHP 8.2 and 8.3 warnings.

Tested with WordPress 6.8.2
Tested with PHP `7.0`, `7.4`, `8.0`, `8.2`, `8.3`

How to test:
1. Clone the plugin under your working directory
2. Using `wp-env` to test, if you haven't installed it, please visit [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/#quick-tldr-instructions) for instructions
It'll be easier to have a `.wp-env.json` file in the root folder. For example, if your root folder is blogger-importer, you can clone the plugin under this folder. Create a `.wp-env.json` file; you can change the PHP version to the one you want to test with.
```json
{
  "phpVersion": "7.4",
  "plugins": ["./movabletype-importer"]
}
```
Run `wp-env start` to spin up the WordPress.

Navigate to `http://localhost:8888/wp-admin/admin.php?import=mt` and upload a file.
Import the content; it can take a while if you have a lot of content. If the script timeout, you need to `set_time_limit` to a higher value.
Now add a new section to `.wp-env.json` and mount the file in `wp-content`:
```
{
    "mappings": {
        ...
        "wp-content/mt-export.txt": "./mt-export.txt"
    }
}
```
Perform an import by clicking the `Import mt-export.txt` button. Check and see if the import works fine without errors and warnings.